### PR TITLE
Fix action

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
 const process = require("process");
 const path = require("path");
 
-exports.tuistEnvPath = path.join(process.cwd(), "tuist");
+exports.tuistEnvPath = path.join(process.cwd(), "tuistexec");

--- a/src/downloadFile.js
+++ b/src/downloadFile.js
@@ -1,9 +1,25 @@
 const https = require("https");
 const fs = require("fs");
 
-module.exports = (url, into) => {
-  const file = fs.createWriteStream(into);
-  https.get(url, (response) => {
-    response.pipe(file);
-  });
+function downloadFileFollowRedirect(url, file, resolve) {
+    https.get(url, (response) => {
+        if (response.statusCode === 301 || response.statusCode === 302) {
+            return downloadFileFollowRedirect(response.headers.location, file, resolve)
+        } else {
+            response.pipe(file);
+            file.on('finish', function () {
+                file.close(function () {
+                    resolve();
+                })
+            });
+        }
+    });
+}
+
+module.exports = async (url, into) => {
+    const file = fs.createWriteStream(into);
+    let promise = new Promise((resolve, reject) => {
+        downloadFileFollowRedirect(url, file, resolve);
+    });
+    await promise;
 };

--- a/src/installTuist.js
+++ b/src/installTuist.js
@@ -10,11 +10,12 @@ module.exports = async () => {
   const tmpobj = tmp.dirSync();
   const tuistEnvTmpZipPath = path.join(tmpobj.name, "tuistenv.zip");
   const tuistEnvUnzippedPath = path.join(tmpobj.name, "tuistenv");
+  const tuistExecEnvUnzippedPath = path.join(tuistEnvUnzippedPath, "tuistenv");
   const tuistEnvURL = await latestReleaseTuistEnvDownloadURL();
   console.log("Downloading Tuist...");
-  downloadFile(tuistEnvURL, tuistEnvTmpZipPath);
+  await downloadFile(tuistEnvURL, tuistEnvTmpZipPath);
   execSync(`unzip -o ${tuistEnvTmpZipPath} -d ${tuistEnvUnzippedPath}`);
-  execSync(`cp ${tuistEnvUnzippedPath} ${tuistEnvPath}`);
+  execSync(`cp ${tuistExecEnvUnzippedPath} ${tuistEnvPath}`);
   execSync(`chmod +x ${tuistEnvPath}`);
   console.log("Tuist has been installed.");
 };


### PR DESCRIPTION
The action wasn't working in it's current state. 
The code for downloading tuist didn't handle the redirect and wasn't async. The next commands weren't waiting for the download to finish and would failed.
I also renamed the tuist exec to 'tuistexec' because the action could fail if you already had a directory named 'tuist' at the root of your project.

Fix for #2 