### PR TITLE
Adds support for environment variables

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
-name: Tuist
+name: Tuist + Environment variable
 description: "Run Tuist in continuous integration"
 inputs: 
+  environment: 
+    description: "The environment variable to pass to the command as prefix"
+    required: false
   arguments: 
     description: "The arguments to pass to the command"
     required: false

--- a/src/input.js
+++ b/src/input.js
@@ -1,5 +1,7 @@
 const core = require('@actions/core');
 
+exports.environment = () => core.getInput('environment', { required: false });
+
 exports.command = () => core.getInput('command', { required: true });
 
 exports.args = () => core.getInput('arguments', { required: false });

--- a/src/input.test.js
+++ b/src/input.test.js
@@ -35,4 +35,20 @@ describe('input', () => {
       });
     });
   });
+
+  describe('environment', () => {
+    it('returns the right value', () => {
+      // Given
+      core.getInput.mockReturnValue('TUIST_IS_CI=true');
+
+      // Then
+      const got = input.environment();
+
+      // Then
+      expect(got).toEqual('TUIST_IS_CI=true');
+      expect(core.getInput).toHaveBeenCalledWith('environment', {
+        required: false,
+      });
+    });
+  });
 });

--- a/src/run.js
+++ b/src/run.js
@@ -8,6 +8,7 @@ const ensureDarwin = require('./ensureDarwin');
 
 module.exports = async () => {
   try {
+    const environment = input.environment();
     const command = input.command();
     const args = input.args();
 
@@ -15,6 +16,9 @@ module.exports = async () => {
     await installTuist();
 
     let execCommand = `${tuistEnvPath} ${command}`;
+    if (environment) {
+      execCommand = `${environment} ${execCommand}`;
+    }
     if (args) {
       execCommand = `${execCommand} ${args}`;
     }

--- a/src/run.test.js
+++ b/src/run.test.js
@@ -39,6 +39,7 @@ describe('run', () => {
 
   it('runs the command', async () => {
     // Given
+    input.environment.mockReturnValue('TUIST_IS_CI=true');
     input.command.mockReturnValue('generate');
     input.args.mockReturnValue('--open');
     isTuistInstalled.mockReturnValue(true);
@@ -48,7 +49,7 @@ describe('run', () => {
 
     // Then
     expect(execSync).toHaveBeenCalledWith(
-      `${tuistEnvPath} generate --open`,
+      `TUIST_IS_CI=true ${tuistEnvPath} generate --open`,
     );
   });
 


### PR DESCRIPTION
This PR adds support for the environment variables. 
As per the `Tuist` documentation, there are certain scenarios where you might need to customize the projects at generation time.
To facilitate that, Tuist allows passing configuration through environment variables that can be accessed from the manifest files.
The idea is to be able to invoke Tuist with the extra, not mandatory, input environment ahead of the command call.

**Regarding unit tests**
I'm not a javascript/node expert; unit tests were already not passing, I spent a bit trying to fix them with no luck. I've added the tests on `input.test.js` and they work. 

